### PR TITLE
Fix grub menuentry parsing on non-english systems

### DIFF
--- a/kexec-reboot
+++ b/kexec-reboot
@@ -89,7 +89,7 @@ end
 def grub1_kernel_entries(config)
   device_map = IO.read("/boot/grub/device.map")
   entries = Array.new
-  config.scan(/title (.+?$).+?root \(([^\)]+)\).+?kernel ([^ ]+) (.+?)$.+?initrd (.+?$)/ms).each do |entry|
+  config.scan(/title (.+?$).+?root \(([^\)]+)\).+?kernel ([^ ]+) (.+?)$.+?initrd (.+?$)/mu).each do |entry|
     begin
       # Try hard-coded locations, works 99.9% of the time
       mount_point = locate_kernel(entry[2])
@@ -123,7 +123,7 @@ end
 # Load the available kernels from the given GRUB 2 configuration file
 def grub2_kernel_entries(config)
   entries = Array.new
-  config.scan(/menuentry '([^']+)'.+?\{.+?search.+?([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|[0-9A-F]{4}-[0-9A-F]{4}).+?\s+linux(efi|16)?\s+([^ ]+) (.+?)$.+?initrd(efi|16)?\s+(.+?)$.+?\}/ms).each do |entry|
+  config.scan(/menuentry '([^']+)'.+?\{.+?search.+?([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|[0-9A-F]{4}-[0-9A-F]{4}).+?\s+linux(efi|16)?\s+([^ ]+) (.+?)$.+?initrd(efi|16)?\s+(.+?)$.+?\}/mu).each do |entry|
     mount_point = uuid_to_mount_point(entry[1])
     name = entry[0].strip
     kernel = "#{mount_point}#{entry[3]}"


### PR DESCRIPTION
Non-English installations can produce a grub configuration that contain unicode characters.
Set the regular expression encoding to UTF-8 instead of Windows-31J.

I wasn't able to test this patch against grub 1.