### PR TITLE
Ignore amd & intel ucode initrd's, making this work on systems with ucodes installed

### DIFF
--- a/kexec-reboot
+++ b/kexec-reboot
@@ -127,7 +127,7 @@ def grub2_kernel_entries(config)
     mount_point = uuid_to_mount_point(entry[1])
     name = entry[0].strip
     kernel = "#{mount_point}#{entry[3]}"
-    initrd = "#{mount_point}#{entry[6]}"
+    initrd = "#{mount_point}#{entry[6].gsub(/\/(?:[^\s\/]+\/)*(?:amd|intel)-ucode\.img/,'').strip}"
     cmdline = entry[4].strip
     # Sanity check the kernel and initrd; they must be present
     if !File.readable?(kernel) then


### PR DESCRIPTION
I've made this script ignore any intel or amd microcode images, making it work on distros with such packages installed (such as Arch Linux with `amd-ucode` installed). This fixes the major issue mentioned in #8 (the script failing when microcode is installed), but does not actually implement multiple initrd support. It simply removes any initrd's named `intel-ucode.img` or `amd-ucode.img` from the argument list.

As [this comment on issue #8 states](https://github.com/error10/kexec-reboot/issues/8#issuecomment-862103151), microcodes persist kexec's and cannot be loaded twice, so this should be fine.

Only affects GRUB 2, tested on two Arch Linux installations with GRUB 2, one with only `amd-ucode` and one with both `intel-ucode` and `amd-ucode`. Does not affect initrd's on GRUB 1 (*since i do not have a system with GRUB 1*)